### PR TITLE
adds Socket.io-Client and ioEvent Subjects Behaviors

### DIFF
--- a/client/src/app/chat/chat.component.ts
+++ b/client/src/app/chat/chat.component.ts
@@ -1,32 +1,55 @@
 import { Component, OnInit,OnDestroy } from '@angular/core';
-import { ChatService }       from './chat.service';
+import { IO } from './../subjects/socket-io';
+import { ioEvent } from './../subjects/io-event';
 
 @Component({
   selector: 'chat-component',
   template: `<div *ngFor="let message of messages">
               {{message.text}}
              </div>
-             <input [(ngModel)]="message" /><button (click)="sendMessage()">Send</button>`,
-  providers: [ChatService]
+             <input [(ngModel)]="message" /><button (click)="sendMessage()">Send</button>
+             <button (click)="connect()">{{connected ? 'Disconnect' : 'Connect'}}</button>`,
+  providers: [IO]
 })
 export class ChatComponent implements OnInit, OnDestroy {
   messages = [];
   connection;
   message;
-  
-  constructor(private chatService:ChatService) {}
+  onJoin: ioEvent;
+  onMessage: ioEvent;
+
+  constructor(private socket:IO) {
+    this.onJoin = new ioEvent({name: 'on-join', once: false});
+    this.onMessage = new ioEvent({name: 'message', once: false});
+    socket.listenToEvent(this.onJoin);
+  }
+  public get connected() { return this.socket.connected; }
+  public connect() {
+    this.socket.connect();
+  }
 
   sendMessage(){
-    this.chatService.sendMessage(this.message);
+    let message = {text: this.message, type: 'new-message'};
+    this.socket.emit('add-message', message);
     this.message = '';
   }
 
   ngOnInit() {
-    this.connection = this.chatService.getMessages().subscribe(message => {
+    this.connection = this.socket.event$.subscribe(socketState => {
+      console.log(`socket state changed:`, socketState)
+    });
+
+    this.onMessage.event$.subscribe((message) => {
+      console.log(message);
       this.messages.push(message);
+    });
+
+    this.onJoin.event$.subscribe(eventData => {
+      console.log('user',eventData.data,'has joined');
     })
+
   }
-  
+
   ngOnDestroy() {
     this.connection.unsubscribe();
   }

--- a/client/src/app/subjects/interfaces-and-initial.ts
+++ b/client/src/app/subjects/interfaces-and-initial.ts
@@ -1,0 +1,9 @@
+/**
+ * Created by Mosh Mage on 12/16/2016.
+ */
+export interface IoEventInfo { name: string, count?: number; once?: boolean}
+export interface ReceivedEvent { name: string, data?: any; }
+export interface SocketState { connected: boolean, id?: string; }
+
+export const initialEvent: ReceivedEvent = {name: "", data: {}};
+export const initialState: SocketState = {connected: false};

--- a/client/src/app/subjects/io-event.ts
+++ b/client/src/app/subjects/io-event.ts
@@ -1,0 +1,53 @@
+import {IoEventInfo, initialEvent, ReceivedEvent} from "./interfaces-and-initial";
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
+export class ioEvent {
+  private clientSocket: any;
+  private _lastEvent: BehaviorSubject<ReceivedEvent> = new BehaviorSubject<ReceivedEvent>(initialEvent);
+  private _onUpdate: Function;
+  private updateData(newData) {
+    this._lastEvent.next(newData);
+    this.event.count++; /** we will be using "count" has a way of knowing if it has been triggered. */
+    if (this._onUpdate) this._onUpdate(newData); /** a way for us to extend properly */
+  }
+
+  constructor(public event: IoEventInfo) {
+    this.event = event;
+  }
+
+  public event$ = this._lastEvent.asObservable();
+  public get hasTriggered() { return this.event.count > 0; }
+  public get isUnique() {return this.event.once === true; }
+  public get name() {return this.event.name; }
+
+  /** */
+  public get onUpdate() {return this._onUpdate;}
+
+  /** hook() is an alias to `socket.on()` or `socket.once()` depending on the provided `IoEventInfo` */
+  public hook(clientSocket) :void {
+    this.clientSocket = clientSocket;
+    if (this.event.once) {
+      this.event.count = 0;
+      this.clientSocket.once(this.event.name, (data) => this.updateData(data));
+    }
+    else this.clientSocket.on(this.event.name, (data) => this.updateData(data));
+
+    /** This is where magic happens. The callback for every ioEvent is a `SubjectBehavior.next()` call
+     * so we can safely `.subscribe()` to the public `event$` prop that each ioEvent has */
+  }
+
+  /** unhook is an alias for "off", and since we only have one real callback attached to the Emitter
+   * we don't need to pass a `fn` argument */
+  public unhook() :void {
+    if (this.event.once) return;
+    this.clientSocket.off(this.event.name);
+  }
+
+  /** a reference to the subscription .getValue() */
+  public get lastEvent() {return this._lastEvent.getValue(); }
+
+  /** ioEvent.onUpdate will be called with `newData` if it's truthy */
+  public set onUpdate(fn: Function) {
+    this._onUpdate = fn;
+  }
+}

--- a/client/src/app/subjects/socket-io.ts
+++ b/client/src/app/subjects/socket-io.ts
@@ -1,0 +1,95 @@
+import {ioEvent} from "./io-event";
+import {SocketState, initialState} from "./interfaces-and-initial";
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import * as io from 'socket.io-client';
+
+const SOCKET_URL = "http://localhost:5000";
+
+export class IO {
+  /** this will be set as a reference to io.Socket */
+  private socket: any;
+
+  /** events will be used to push which events we should be listening to */
+  private events: ioEvent[] = [];
+
+  private _socketState: BehaviorSubject<SocketState> = new BehaviorSubject<SocketState>(initialState);
+  public event$ = this._socketState.asObservable();
+
+  /** this prop will pretty much control the "is connected" or not.
+   * it also controls whether or not we should issue this.socket.disconnect() */
+  private _connected: boolean = false;
+
+  constructor() {}
+
+  /** a reference to the subscription .getValue() */
+  public get socketState() {return this._socketState.getValue(); }
+
+  /** an alias for Socket.emit() */
+  public emit(eventName: string, data: Object) {
+    console.log(this.connected)
+    if (this.connected) {
+      this.socket.emit(eventName, data);
+    }
+  }
+
+  /** check if Event exists so we don't pollute the events list with dupes
+   * EVEN if it's a `once` event, as one change will trigger all listeners */
+  public eventExists(ioEvent :ioEvent) :boolean {
+    return this.events.some(_ioEvent => {
+      return !_ioEvent.hasTriggered && _ioEvent.isUnique && _ioEvent.name === ioEvent.name ||
+        !_ioEvent.isUnique && _ioEvent.name === ioEvent.name;
+    });
+  }
+
+  /** pushes an ioEvent to be heard */
+  public listenToEvent(ioEvent: ioEvent) :void {
+    if (!this.eventExists(ioEvent)) this.events.push(ioEvent);
+  }
+
+  /**
+   * Makes a new connection to the @SOCKET_URL const and sets up a `on connect` by default
+   * which will in turn update the @this._socketState Subject with the GameEvent containing
+   * the received data as an argument (as well as the event-name)
+   * @param nickname {String}     used on first connect emit
+   * @param forceNew {Boolean}
+   */
+  public connect(address?: string, forceNew?:boolean) :void {
+    if (this.connected && !forceNew) return;
+    else if (this.connected && forceNew) this.connected = false;
+
+    this.socket = io(address || SOCKET_URL);
+    this.socket.on('connect', () => {
+      this.connected = true;
+      this.socket.emit('hello',{world: 'rimshot'});
+
+      this._socketState.next({connected: true, id: this.socket.id || 1 });
+      this.events.forEach(ioEvent => {
+        /** this is where we hook our previously new()ed ioEvents to the socket.
+         * This is so we can have one listener per event. as opposed to one event
+         * to all listeners (that would kinda defeat the "io" part of "SocketIO")
+         * */
+        ioEvent.hook(this.socket);
+      });
+
+      this.socket.on('disconnect', () => {
+        this.connected = false;
+      })
+    });
+  };
+
+  /**
+   * If anyone makes a this.connect = false; the connection to the socket.io should be closed
+   * and another default error set.
+   * @param value
+   * @returns {boolean}
+   */
+  public get connected() {return this._connected; }
+  public set connected(value: boolean) {
+    if (value === false && this.connected) {
+      this.socket.disconnect();
+      this._socketState.next({connected: false});
+    }
+    this._connected = value;
+  };
+  public set socketState(v) {return;}
+}

--- a/server/server.js
+++ b/server/server.js
@@ -6,12 +6,14 @@ let io = require('socket.io')(http);
 
 io.on('connection', (socket) => {
   console.log('user connected');
-  
+  socket.emit('on-join', {nick: "someone"});
+  io.emit('on-join', {nick: "someone"});
   socket.on('disconnect', function(){
     console.log('user disconnected');
   });
   
   socket.on('add-message', (message) => {
+    console.log('gots message', message);
     io.emit('message', {type:'new-message', text: message});    
   });
 });


### PR DESCRIPTION
###### Created by Mosh Mage on 12/15/2016.
### Thanks to
- http://stackoverflow.com/questions/34376854/delegation-eventemitter-or-observable-in-angular2/35568924#35568924
- http://www.syntaxsuccess.com/viewarticle/socket.io-with-rxjs-in-angular-2.0 
 
### Why
Main objective was to have a "more than one event" subscription so I could listen to more than one event, as my
whole application is not on a `message` event. That'd be wack.

### How
To do this, I applied RxJs Subject Behavior on a SocketIO wrapper Class that's fed an array of instaces of `ioEvents`; 
Each ioEvent is responsible for itself, that's to say that an ioEvent is the one that issues a `.next()` update on the `Subject`.

You can, and are supposed to, `extend` on the `ioEvent` Class - treat this as you would behaviors, because that's all they are. You can `extends ioEvent` and then use `this.onUpdate = (newData) => {}` to run some function *after* the update has been ran on its `ioEvent.updateData` counterpart.

### All in all
RxJs is indeed useful, besides fun. and you can "see" the EventEmitter base in it which kinda helps understand the "Subject" of it all.

###### pet peeves
I decided against using "Observables" as "Subjects" [*already are*](http://stackoverflow.com/questions/34376854/delegation-eventemitter-or-observable-in-angular2/35568924#35568924)... 
> Observable (so we can subscribe() to it) and an Observer (so we can call next() on it to emit a new value).